### PR TITLE
お気に入り機能実装

### DIFF
--- a/app/assets/javascripts/likes.coffee
+++ b/app/assets/javascripts/likes.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -63,7 +63,7 @@ $dark-gray: #595857;
   background-color: $white;
   color: #2b2b2b;
   padding-left: 10px;
-  font-size: 14px;
+  font-size: 16px;
   padding-top: 10px;
 }
 
@@ -74,6 +74,7 @@ $dark-gray: #595857;
 }
 
 @mixin category{
+  padding-top: 10px;
   height: 50%;
   width: 100%;
   background-color: $white;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,5 +8,6 @@
 @import "modules/edit-user";
 @import "modules/profile";
 @import "modules/category-show";
+@import "modules/likes";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/likes.scss
+++ b/app/assets/stylesheets/likes.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the likes controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/modules/_likes.scss
+++ b/app/assets/stylesheets/modules/_likes.scss
@@ -4,3 +4,30 @@
   line-height: 50px;
   @include main__content--title;
 }
+
+.user__post__info--like{
+  height: 25%;
+  width: 100%;
+  background-color: $white;
+}
+
+.user__post-like{
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 10px;
+  padding-top: 15px;
+}
+
+.like-icon--fav{
+  color: #ffd700;
+}
+
+.like-icon--nofav{
+  color: $dark-gray;
+}
+
+.show__post-like-count--thumbail{
+  color: $dark-gray;
+  font-size: 13px;
+  padding-left: 5px;
+}

--- a/app/assets/stylesheets/modules/_likes.scss
+++ b/app/assets/stylesheets/modules/_likes.scss
@@ -1,0 +1,6 @@
+.list-title--like{
+  background-color: #ffd700;
+  color: $dark-gray;
+  line-height: 50px;
+  @include main__content--title;
+}

--- a/app/assets/stylesheets/modules/_show-user.scss
+++ b/app/assets/stylesheets/modules/_show-user.scss
@@ -64,11 +64,6 @@
         background-color: $white;
       }
     }
-    &--tags{
-      height: 25%;
-      width: 100%;
-      background-color: $white;
-    }
     &--time{
       @include time;
     }

--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -48,6 +48,20 @@
   display: flex;
 }
 
+.show__post-like{
+  margin-top: 10px;
+  display:flex;
+  .like-icon{
+    padding-right: 12px;
+  }
+  .show__post-like-count{
+    margin-top: 7px;
+    color: $dark-gray;
+    padding-right: 15px;
+  }
+}
+
+
 .trash-icon{
   cursor: pointer;
   color: $accent-color;

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,2 @@
+class LikesController < ApplicationController
+end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,2 +1,6 @@
 class LikesController < ApplicationController
+  def create
+    @like = current_user.likes.create(post_id: params[:post_id])
+    redirect_back(fallback_location: post_path)
+  end
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -2,7 +2,7 @@ class LikesController < ApplicationController
   
   def create
     @like = current_user.likes.create(post_id: params[:post_id])
-    redirect_back(fallback_location: post_path)
+    redirect_back(fallback_location: root_path)
   end
 
   def destroy
@@ -10,5 +10,5 @@ class LikesController < ApplicationController
     @like.destroy
     redirect_back(fallback_location: root_path)
   end
-  
+
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,14 +1,15 @@
 class LikesController < ApplicationController
   
   def create
-    @like = current_user.likes.create(post_id: params[:post_id])
-    redirect_back(fallback_location: root_path)
+    @post = Post.find(params[:post_id])
+    like = current_user.likes.create(post_id: params[:post_id])
+    like.save
   end
 
   def destroy
-    @like = Like.find_by(post_id: params[:post_id], user_id: current_user.id)
-    @like.destroy
-    redirect_back(fallback_location: root_path)
+    @post = Post.find(params[:post_id])
+    like = Like.find_by(post_id: params[:post_id], user_id: current_user.id)
+    like.destroy
   end
 
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,6 +1,14 @@
 class LikesController < ApplicationController
+  
   def create
     @like = current_user.likes.create(post_id: params[:post_id])
     redirect_back(fallback_location: post_path)
   end
+
+  def destroy
+    @like = Like.find_by(post_id: params[:post_id], user_id: current_user.id)
+    @like.destroy
+    redirect_back(fallback_location: root_path)
+  end
+  
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,5 +1,10 @@
 class LikesController < ApplicationController
   
+  def index
+    @user = User.find(params[:user_id])
+    @likes = Like.where(user_id: @user.id).includes(:user)
+  end
+
   def create
     @post = Post.find(params[:post_id])
     like = current_user.likes.create(post_id: params[:post_id])

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,6 +25,7 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     @comment = Comment.new
     @comments = @post.comments.includes(:user)
+    @like = Like.new
   end
 
   def edit

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,4 @@
+class Like < ApplicationRecord
+  belongs_to :post
+  belongs_to :user
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,4 +1,6 @@
 class Like < ApplicationRecord
   belongs_to :post
   belongs_to :user
+  
+  validates_uniqueness_of :post_id, scope: :user_id
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,8 +2,10 @@ class Post < ApplicationRecord
   validates :title, :text, :image, presence: true
   
   belongs_to :user
-  has_many :comments
+  has_many :comments, dependent: :destroy
   belongs_to :category
+  has_many :likes
+  has_many :liked_users, through: :likes, source: :user
 
   mount_uploader :image, ImageUploader
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,5 +7,9 @@ class Post < ApplicationRecord
   has_many :likes
   has_many :liked_users, through: :likes, source: :user
 
+  def liked_by?(user)
+    likes.where(user_id: user.id).exists?
+  end
+
   mount_uploader :image, ImageUploader
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,10 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_posts, through: :likes, source: :post
-  
+
+  def already_liked?(post)
+    self.likes.exists?(post_id: post.id)
+  end
+
   mount_uploader :image, ImageUploader
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,9 +9,5 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_posts, through: :likes, source: :post
 
-  def already_liked?(post)
-    self.likes.exists?(post_id: post.id)
-  end
-
   mount_uploader :image, ImageUploader
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,10 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   
-  has_many :posts
-  has_many :comments
+  has_many :posts, dependent: :destroy
+  has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
+  has_many :liked_posts, through: :likes, source: :post
+  
   mount_uploader :image, ImageUploader
 end

--- a/app/views/likes/_like.html.haml
+++ b/app/views/likes/_like.html.haml
@@ -1,0 +1,9 @@
+- if user_signed_in?
+  - if post.liked_by?(current_user)
+    = link_to "/posts/#{post.id}/likes/#{post.id}", method: :delete, style:"color:#ffd700", remote: true do
+      = icon('fas', 'star fa-2x', class: 'like-icon')
+  - else
+    = link_to post_likes_path(post.id), method: :post, remote: true do
+      = icon('fas', 'star fa-2x', class: 'like-icon')
+  .show__post-like-count
+    = post.likes.count

--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,0 +1,1 @@
+$('.show__post-like').html("<%= j(render partial: 'likes/like', locals: {post: @post}) %>");

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,0 +1,1 @@
+$('.show__post-like').html("<%= j(render partial: 'likes/like', locals: {post: @post}) %>");

--- a/app/views/likes/index.html.haml
+++ b/app/views/likes/index.html.haml
@@ -1,2 +1,51 @@
-- @likes.each do |like|
-  = like.post.title
+.mypage
+  .user__posts
+    %p.list-title--like
+      = "#{@user.nickname}さんのお気に入り"
+      .new-posts-index
+        - @likes.each do |like|
+          .user__post
+            = link_to "", post_path(like.post.id)
+            .user__post__image
+              = image_tag like.post.image.url(:thumb), class: 'show__image--top'
+            .user__post__info
+              .user__post__info--user
+                .user__userimage
+                  = image_tag like.post.user.image.url(:thumb100), class: "show__image--user"
+                .user__user-status
+                  .user__nickname
+                    = like.post.user.nickname
+              .user__post__info--title
+                = like.post.title
+              .user__post__info--status
+                .user__post-category 
+                  = "カテゴリ：#{like.post.category.name}"
+                -#.user__post-erea 北米>アメリカ>シカゴ
+              .user__post__info--tags
+              .user__post__info--time
+                %p.create-time
+                  = like.post.created_at.to_s(:datetime_jp)
+  .profile
+    .profile__user
+      .profile__user--image
+        = image_tag @user.image.url(:thumb200), class: "show__image--user"
+      .profile__user--status
+        %p.user-info__nickname
+          = link_to "#{@user.nickname}", "/users/#{@user.id}"
+      -if user_signed_in? && current_user.id == @user.id
+        .profile__user--edit
+          = link_to edit_user_path(current_user.id) do
+            = icon('fas', 'user-edit', class: 'user-edit-icon')
+    %ul.user-connection
+      %li.user-connection__list
+        %p.user-connection__list--follow フォロー
+        = link_to "2", "#"
+      %li.user-connection__list
+        %p.user-connection__list--followers フォロワー
+        = link_to "1", "#"
+      %li.user-connection__list
+        %p.user-connection__list--favorite お気に入り
+        = link_to "#{@user.likes.count}", user_likes_path(@user.id)
+    .profile__biography
+      = simple_format @user.biography
+    = link_to "投稿数 #{@user.posts.count}", user_path(@user.id), class: "profile__post"

--- a/app/views/likes/index.html.haml
+++ b/app/views/likes/index.html.haml
@@ -21,7 +21,15 @@
                 .user__post-category 
                   = "カテゴリ：#{like.post.category.name}"
                 -#.user__post-erea 北米>アメリカ>シカゴ
-              .user__post__info--tags
+              .user__post__info--like
+                .user__post-like
+                  - if user_signed_in?
+                    - if like.post.liked_by?(current_user)
+                      = icon('fas', 'star', class: 'like-icon--fav')
+                    - else
+                      = icon('fas', 'star', class: 'like-icon--nofav')
+                    .show__post-like-count--thumbail
+                      = like.post.likes.count
               .user__post__info--time
                 %p.create-time
                   = like.post.created_at.to_s(:datetime_jp)

--- a/app/views/likes/index.html.haml
+++ b/app/views/likes/index.html.haml
@@ -1,0 +1,2 @@
+- @likes.each do |like|
+  = like.post.title

--- a/app/views/posts/_postthumbnail.html.haml
+++ b/app/views/posts/_postthumbnail.html.haml
@@ -17,7 +17,15 @@
           .user__post-category 
             = "カテゴリ：#{post.category.name}"
           -#.user__post-erea 北米>アメリカ>シカゴ
-        .user__post__info--tags
+        .user__post__info--like
+          .user__post-like
+            - if user_signed_in?
+              - if post.liked_by?(current_user)
+                = icon('fas', 'star', class: 'like-icon--fav')
+              - else
+                = icon('fas', 'star', class: 'like-icon--nofav')
+              .show__post-like-count--thumbail
+                = post.likes.count
         .user__post__info--time
           %p.create-time
             = post.created_at.to_s(:datetime_jp)

--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -52,7 +52,7 @@
         = link_to "1", "#"
       %li.user-connection__list
         %p.user-connection__list--favorite お気に入り
-        = link_to "7", "#"
+        = link_to "#{current_user.likes.count}", "#"
     .profile__biography
       = simple_format @user_biography
     = link_to "投稿数 #{current_user.posts.count}", user_path(current_user.id), class: "profile__post"

--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -52,7 +52,7 @@
         = link_to "1", "#"
       %li.user-connection__list
         %p.user-connection__list--favorite お気に入り
-        = link_to "#{current_user.likes.count}", "#"
+        = link_to "#{current_user.likes.count}",user_likes_path(current_user.id)
     .profile__biography
       = simple_format @user_biography
     = link_to "投稿数 #{current_user.posts.count}", user_path(current_user.id), class: "profile__post"

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -52,7 +52,7 @@
         = link_to "1", "#"
       %li.user-connection__list
         %p.user-connection__list--favorite お気に入り
-        = link_to "7", "#"
+        = link_to "#{current_user.likes.count}", "#"
     .profile__biography
       = simple_format @user_biography
     = link_to "投稿数 #{current_user.posts.count}", user_path(current_user.id), class: "profile__post"

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -52,7 +52,7 @@
         = link_to "1", "#"
       %li.user-connection__list
         %p.user-connection__list--favorite お気に入り
-        = link_to "#{current_user.likes.count}", "#"
+        = link_to "#{current_user.likes.count}",user_likes_path(current_user.id)
     .profile__biography
       = simple_format @user_biography
     = link_to "投稿数 #{current_user.posts.count}", user_path(current_user.id), class: "profile__post"

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -7,14 +7,7 @@
         .show__title
           = @post.title
         .show__post-like
-          - if current_user.already_liked?(@post)
-            = link_to post_like_path(@post), method: :delete, style:"color:#ffd700" do
-              = icon('fas', 'star fa-2x', class: 'like-icon')
-          - else
-            = link_to post_likes_path(@post), method: :post do
-              = icon('fas', 'star fa-2x', class: 'like-icon')
-          .show__post-like-count
-            = @post.likes.count
+          = render partial: "likes/like", locals: { post: @post }
         - if user_signed_in? && current_user.id == @post.user_id
           .show__post-user
             .show__edit

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -65,7 +65,7 @@
         = link_to "1", "#"
       %li.user-connection__list
         %p.user-connection__list--favorite お気に入り
-        = link_to "#{@post.likes.count}",user_likes_path(@post.user.id)
+        = link_to "#{@post.user.likes.count}",user_likes_path(@post.user.id)
     .profile__biography
       = simple_format @post.user.biography
     = link_to "投稿数 #{@post.user.posts.count}", user_path(@post.user.id), class: "profile__post"

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -72,7 +72,7 @@
         = link_to "1", "#"
       %li.user-connection__list
         %p.user-connection__list--favorite お気に入り
-        = link_to "7", "#"
+        = link_to "#{@post.likes.count}", "#"
     .profile__biography
       = simple_format @post.user.biography
     = link_to "投稿数 #{@post.user.posts.count}", user_path(@post.user.id), class: "profile__post"

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -65,7 +65,7 @@
         = link_to "1", "#"
       %li.user-connection__list
         %p.user-connection__list--favorite お気に入り
-        = link_to "#{@post.likes.count}", "#"
+        = link_to "#{@post.likes.count}",user_likes_path(@post.user.id)
     .profile__biography
       = simple_format @post.user.biography
     = link_to "投稿数 #{@post.user.posts.count}", user_path(@post.user.id), class: "profile__post"

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -6,6 +6,15 @@
       .show__titleandedit
         .show__title
           = @post.title
+        .show__post-like
+          - if current_user.already_liked?(@post)
+            = link_to post_like_path(@post), method: :delete, style:"color:#ffd700" do
+              = icon('fas', 'star fa-2x', class: 'like-icon')
+          - else
+            = link_to post_likes_path(@post), method: :post do
+              = icon('fas', 'star fa-2x', class: 'like-icon')
+          .show__post-like-count
+            = @post.likes.count
         - if user_signed_in? && current_user.id == @post.user_id
           .show__post-user
             .show__edit

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -23,7 +23,7 @@
         = link_to "1", "#"
       %li.user-connection__list
         %p.user-connection__list--favorite お気に入り
-        = link_to "#{@user.likes.count}", "#"
+        = link_to "#{@user.likes.count}", user_likes_path(@user.id)
     .profile__biography
       = simple_format @user.biography
     = link_to "投稿数 #{@user.posts.count}", user_path(@user.id), class: "profile__post"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -23,7 +23,7 @@
         = link_to "1", "#"
       %li.user-connection__list
         %p.user-connection__list--favorite お気に入り
-        = link_to "7", "#"
+        = link_to "#{@user.likes.count}", "#"
     .profile__biography
       = simple_format @user.biography
     = link_to "投稿数 #{@user.posts.count}", user_path(@user.id), class: "profile__post"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
     resources :likes, only: [:create, :destroy]
   end
 
-  resources :users, only: [:show, :edit, :update]
+  resources :users, only: [:show, :edit, :update] do
+    resources :likes, only: :index
+  end
+
   resources :categories, only: :show
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   
   resources :posts do
     resources :comments, only: :create
+    resources :likes, only: [:create, :destroy]
   end
 
   resources :users, only: [:show, :edit, :update]

--- a/db/migrate/20200511085221_create_likes.rb
+++ b/db/migrate/20200511085221_create_likes.rb
@@ -1,0 +1,10 @@
+class CreateLikes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :likes do |t|
+      t.references :post, foreign_key: true
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_11_032116) do
+ActiveRecord::Schema.define(version: 2020_05_11_085221) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -26,6 +26,15 @@ ActiveRecord::Schema.define(version: 2020_05_11_032116) do
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "post_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -57,4 +66,6 @@ ActiveRecord::Schema.define(version: 2020_05_11_032116) do
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
 end

--- a/test/controllers/likes_controller_test.rb
+++ b/test/controllers/likes_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LikesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/likes.yml
+++ b/test/fixtures/likes.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  post: one
+  user: one
+
+two:
+  post: two
+  user: two

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LikeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
投稿をお気に入りできる機能を実装。
posts/showのページでお気に入りをしたり外したりできる。
お気に入りボタン★は非同期で実装。
投稿サムネイルにその投稿にいくつお気に入りがされているか表示。
ユーザーがお気に入りした一覧を表示するページを作成。

# Why
何度も見返したい投稿などはお気に入りを使い、お気に入り一覧で表示できるようにすることによって、いつでもその投稿を見返すことができるため。
非同期で実装することによりユーザビリティを向上。